### PR TITLE
ci: add GitHub Actions workflow for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,9 @@ jobs:
       matrix:
         platform: [debian, fedora]
         test: [install, prompt]
+    name: e2e / ${{ matrix.platform }} / ${{ matrix.test }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build ${{ matrix.platform }} image
-        run: |
-          docker build \
-            -t n2-e2e-${{ matrix.platform }} \
-            -f tests/e2e/platforms/${{ matrix.platform }}.Dockerfile \
-            .
-
-      - name: Run test_${{ matrix.test }} on ${{ matrix.platform }}
-        run: |
-          docker run --rm n2-e2e-${{ matrix.platform }} \
-            bash tests/e2e/tests/test_${{ matrix.test }}.sh
+      - name: Run E2E test
+        run: ./tests/e2e/run.sh --platform ${{ matrix.platform }} --test ${{ matrix.test }}


### PR DESCRIPTION
Closes #18

Adds a CI workflow that runs the existing Docker-based e2e test suite on every push to master and on pull requests.

**What it does:**
- Builds Docker images for each platform (debian, fedora)
- Runs each test (install, prompt) in the corresponding container
- Uses a matrix strategy so all 4 combinations run in parallel
- `fail-fast: false` so all tests complete even if one fails

**Workflow file:** `.github/workflows/ci.yml`