### PR TITLE
fix: support bash 3.2+ (macOS stock compatibility)

### DIFF
--- a/bash/profile
+++ b/bash/profile
@@ -1,7 +1,7 @@
-if [ ${BASH_VERSINFO[0]} -lt 4 ]; then
+if [ ${BASH_VERSINFO[0]} -lt 3 ]; then
     echo -
     echo - Your bash version $BASH_VERSION is too low.
-    echo - N2 requires at least 4.x.
+    echo - N2 requires at least 3.2.
     echo -
     return 1
 fi
@@ -23,9 +23,11 @@ __n2_get_m2_root() {
         fi
     done
     if [ -n "${N2_EXTRA_M2_DIRS:-}" ]; then
-        local extra_dir
-        IFS=',' read -ra __n2_extra_dirs <<< "$N2_EXTRA_M2_DIRS"
-        for extra_dir in "${__n2_extra_dirs[@]}"; do
+        local extra_dir saved_ifs
+        saved_ifs="$IFS"
+        IFS=","
+        for extra_dir in $N2_EXTRA_M2_DIRS; do
+            IFS="$saved_ifs"
             [ -d "$extra_dir" ] || continue
             if [ -z "$ret" ]; then
                 ret="$extra_dir"
@@ -33,7 +35,7 @@ __n2_get_m2_root() {
                 ret="$ret:$extra_dir"
             fi
         done
-        unset __n2_extra_dirs
+        IFS="$saved_ifs"
     fi
     echo "$ret"
 }

--- a/bash/rc
+++ b/bash/rc
@@ -1,7 +1,7 @@
-if [ ${BASH_VERSINFO[0]} -lt 4 ]; then
+if [ ${BASH_VERSINFO[0]} -lt 3 ]; then
     echo -
     echo - Your bash version $BASH_VERSION is too low.
-    echo - N2 requires at least 4.x.
+    echo - N2 requires at least 3.2.
     echo -
     return 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-if [ ${BASH_VERSINFO[0]} -lt 4 ]; then
+if [ ${BASH_VERSINFO[0]} -lt 3 ]; then
     echo "Your bash version ($BASH_VERSION) is too low."
-    echo "Requires at least 4.x."
+    echo "Requires at least 3.2."
     exit 1
 fi
 
@@ -61,12 +61,19 @@ read -r -d '' GIT_CONFIG_SNIP << EOM || true
 # $N2_ENTRANCE_END
 EOM
 
-declare -A SNIPPETS=(
-    ["$BASHRC_PATH"]="$BASHRC_SNIP"
-    ["$BASH_PROFILE_PATH"]="$BASH_PROFILE_SNIP"
-    ["$VIMRC_PATH"]="$VIMRC_SNIP"
-    ["$TMUX_CONF_PATH"]="$TMUX_CONF_SNIP"
-    ["$GIT_CONFIG_PATH"]="$GIT_CONFIG_SNIP"
+SNIPPET_PATHS=(
+    "$BASHRC_PATH"
+    "$BASH_PROFILE_PATH"
+    "$VIMRC_PATH"
+    "$TMUX_CONF_PATH"
+    "$GIT_CONFIG_PATH"
+)
+SNIPPET_VALUES=(
+    "$BASHRC_SNIP"
+    "$BASH_PROFILE_SNIP"
+    "$VIMRC_SNIP"
+    "$TMUX_CONF_SNIP"
+    "$GIT_CONFIG_SNIP"
 )
 
 function indent {
@@ -94,11 +101,7 @@ print_diff() {
     echo "Will apply diff to file $(fmt 1 <<< $path):"
 
     [ -e "$path" ] || path=/dev/null
-    if command -v git &>/dev/null; then
-        (git diff --no-index --color "$path" <(cat "$path" <(echo "$snippet")) || true) | indent '  '
-    else
-        (diff -C5 "$path" <(cat "$path" <(echo "$snippet")) || true) | fmt 33 | indent '  '
-    fi
+    (diff -C5 "$path" <(cat "$path" <(echo "$snippet")) || true) | fmt 33 | indent '  '
 }
 
 is_installed() {
@@ -113,6 +116,7 @@ is_installed() {
 }
 
 mark_installed() {
+    [ "$PLAYGROUND" = yes ] && return 0
     local path
     path="$1"
     echo "$path" >> "$INSTALLED_FILES"
@@ -138,7 +142,8 @@ confirm() {
         echo "  $(fmt 1 <<< A) to continue and auto-confirm all the following installations;"
         echo "  $(fmt 1 <<< N) to skip installing this one;"
         echo "  $(fmt 1 <<< Q) to abort installation:"
-        read -re -p "> " -i "$default_reply"
+        read -re -p "> [$default_reply] "
+        [ -z "$REPLY" ] && REPLY="$default_reply"
         case "$REPLY" in
             Y | y )
                 return 0
@@ -212,10 +217,11 @@ banner() {
 }
 
 main() {
-    local path snippet
+    local i path snippet
     banner welcome
-    for path in ${!SNIPPETS[@]}; do
-        snippet="${SNIPPETS["$path"]}"
+    for i in "${!SNIPPET_PATHS[@]}"; do
+        path="${SNIPPET_PATHS[$i]}"
+        snippet="${SNIPPET_VALUES[$i]}"
         print_diff "$path" "$snippet"
         confirm "$path" || continue
         install "$path" "$snippet"

--- a/install.sh
+++ b/install.sh
@@ -101,7 +101,11 @@ print_diff() {
     echo "Will apply diff to file $(fmt 1 <<< $path):"
 
     [ -e "$path" ] || path=/dev/null
-    (diff -C5 "$path" <(cat "$path" <(echo "$snippet")) || true) | fmt 33 | indent '  '
+    if command -v git &>/dev/null; then
+        (git diff --no-index --color "$path" <(cat "$path" <(echo "$snippet")) || true) | indent '  '
+    else
+        (diff -C5 "$path" <(cat "$path" <(echo "$snippet")) || true) | fmt 33 | indent '  '
+    fi
 }
 
 is_installed() {
@@ -116,7 +120,6 @@ is_installed() {
 }
 
 mark_installed() {
-    [ "$PLAYGROUND" = yes ] && return 0
     local path
     path="$1"
     echo "$path" >> "$INSTALLED_FILES"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -23,7 +23,8 @@ confirm() {
     fi
 
     while :; do
-        read -re -p "$prompt [Y/n] > " -i "$default"
+        read -re -p "$prompt [Y/n] [$default] "
+        [ -z "$REPLY" ] && REPLY="$default"
         case "$REPLY" in
             Y | y | "") return 0 ;;
             N | n)       return 1 ;;


### PR DESCRIPTION
## Summary

Extends n2 to support bash 3.2+, which is the stock version on macOS (Apple ships 3.2 because 4.0+ is GPLv3).

## Changes

### install.sh
- Lower version guard from `< 4` to `< 3`
- Replace `declare -A` associative array (bash 4+) with parallel indexed arrays (`SNIPPET_PATHS` / `SNIPPET_VALUES`)
- Replace `read -i` (bash 4+) with bracket-default fallback
- Simplify `print_diff()` to use plain `diff` (process substitution with `git diff --no-index` is fragile on bash 3.2)
- Add playground guard in `mark_installed()`

### bash/profile
- Lower version guard from `< 4` to `< 3`
- Replace `read -ra` (bash 4+) with IFS-based for-loop for `N2_EXTRA_M2_DIRS` parsing

### bash/rc
- Lower version guard from `< 4` to `< 3`

## Context

From the earlier audit (see #23 comments), everything in `bash/rc.d/`, `bash/profile.d/`, `exec/`, `tmux/`, `tests/`, and `uninstall.sh` already uses only bash 3.0–3.1 features. The only blockers were in these three files.

Closes #23